### PR TITLE
Reference schema properties from another schema

### DIFF
--- a/release10.0.0/semantic-apis/oas3/yamls/PartyRoutingProfile.yaml
+++ b/release10.0.0/semantic-apis/oas3/yamls/PartyRoutingProfile.yaml
@@ -483,38 +483,17 @@ components:
       type: object
       properties:
         Status:
-          type: object
-          properties:
-            CustomerRelationshipStatusType:
-              type: string
-            CustomerRelationshipStatusNarrative:
-              type: string
-            CustomerRelationshipStatusValidFromOrToDate:
-              type: string
+          $ref: '#/components/schemas/Status'
     UpdateStatusResponse:
       type: object
       properties:
         Status:
-          type: object
-          properties:
-            CustomerRelationshipStatusType:
-              type: string
-            CustomerRelationshipStatusNarrative:
-              type: string
-            CustomerRelationshipStatusValidFromOrToDate:
-              type: string
+          $ref: '#/components/schemas/Status'
     CaptureStatusRequest:
       type: object
       properties:
         Status:
-          type: object
-          properties:
-            CustomerRelationshipStatusType:
-              type: string
-            CustomerRelationshipStatusNarrative:
-              type: string
-            CustomerRelationshipStatusValidFromOrToDate:
-              type: string
+          $ref: '#/components/schemas/Status'
     CaptureStatusResponse:
       type: object
       properties:
@@ -527,50 +506,22 @@ components:
       type: object
       properties:
         Status:
-          type: object
-          properties:
-            CustomerRelationshipStatusType:
-              type: string
-            CustomerRelationshipStatusNarrative:
-              type: string
-            CustomerRelationshipStatusValidFromOrToDate:
-              type: string
+          $ref: '#/components/schemas/Status'
     UpdateRatingRequest:
       type: object
       properties:
         Rating:
-          type: object
-          properties:
-            CustomerRelationshipRatingType:
-              type: string
-            CustomerRelationshipRatingNarrative:
-              type: string
-            CustomerRelationshipRatingValidFromOrToDate:
-              type: string
+          $ref: '#/components/schemas/Rating'
     UpdateRatingResponse:
       type: object
       properties:
         Rating:
-          type: object
-          properties:
-            CustomerRelationshipRatingType:
-              type: string
-            CustomerRelationshipRatingNarrative:
-              type: string
-            CustomerRelationshipRatingValidFromOrToDate:
-              type: string
+          $ref: '#/components/schemas/Rating'
     CaptureRatingRequest:
       type: object
       properties:
         Rating:
-          type: object
-          properties:
-            CustomerRelationshipRatingType:
-              type: string
-            CustomerRelationshipRatingNarrative:
-              type: string
-            CustomerRelationshipRatingValidFromOrToDate:
-              type: string
+          $ref: '#/components/schemas/Rating'
     CaptureRatingResponse:
       type: object
       properties:
@@ -583,50 +534,22 @@ components:
       type: object
       properties:
         Rating:
-          type: object
-          properties:
-            CustomerRelationshipRatingType:
-              type: string
-            CustomerRelationshipRatingNarrative:
-              type: string
-            CustomerRelationshipRatingValidFromOrToDate:
-              type: string
+          $ref: '#/components/schemas/Rating'
     UpdateAlertRequest:
       type: object
       properties:
         Alert:
-          type: object
-          properties:
-            CustomerRelationshipAlertType:
-              type: string
-            CustomerRelationshipAlertNarrative:
-              type: string
-            CustomerRelationshipAlertValidFromOrToDate:
-              type: string
+          $ref: '#/components/schemas/Alert'
     UpdateAlertResponse:
       type: object
       properties:
         Alert:
-          type: object
-          properties:
-            CustomerRelationshipAlertType:
-              type: string
-            CustomerRelationshipAlertNarrative:
-              type: string
-            CustomerRelationshipAlertValidFromOrToDate:
-              type: string
+          $ref: '#/components/schemas/Alert'
     CaptureAlertRequest:
       type: object
       properties:
         Alert:
-          type: object
-          properties:
-            CustomerRelationshipAlertType:
-              type: string
-            CustomerRelationshipAlertNarrative:
-              type: string
-            CustomerRelationshipAlertValidFromOrToDate:
-              type: string
+          $ref: '#/components/schemas/Alert'
     CaptureAlertResponse:
       type: object
       properties:
@@ -639,14 +562,7 @@ components:
       type: object
       properties:
         Alert:
-          type: object
-          properties:
-            CustomerRelationshipAlertType:
-              type: string
-            CustomerRelationshipAlertNarrative:
-              type: string
-            CustomerRelationshipAlertValidFromOrToDate:
-              type: string
+          $ref: '#/components/schemas/Alert'
   parameters:
     PartyRoutingProfileID:
       name: partyroutingprofileId


### PR DESCRIPTION
Signed-off-by: Ilona Shishov <Ilona.Shishov@gmail.com>

Hi,
While implementing the following APIs, I found that model 'RetrieveStatusResponse' was missing the 'CustomerRelationshipStatus' property. 
Also I found that a conversion from openapi to protobuf-schema using openapi-generator results in incorrect auto referencing to other unrelated schemas due to similar property groups.
As a solution to this behavior, I suggest to replace the property groups inside several schemas with a reference to a base schema.

Best regards,
Ilona Shishov